### PR TITLE
Tweak cursor options

### DIFF
--- a/src/momonger/node-mongosync/oplog_reader.coffee
+++ b/src/momonger/node-mongosync/oplog_reader.coffee
@@ -59,8 +59,10 @@ class OplogReader
         sort:
           $natural: 1
         tailable: true
-        awaitdata: true
+        awaitData: true
         timeout: false
+        noCursorTimeout: true
+        oplogReplay: true # Directly seek to the newest oplog documents!
         # batchSize: (@config.options.bulkLimit * 2)
       , (err, cursor) =>
         return done err if err


### PR DESCRIPTION
Well, we're currently troubled by the fact the tailable cursor against oplog does time out for some reason..

After some research, this seems to fix the problem somehow..
