### PR TITLE
Use push+each instead of pushAll

### DIFF
--- a/src/momonger/job/job/index.coffee
+++ b/src/momonger/job/job/index.coffee
@@ -149,10 +149,11 @@ class Mapper extends Job
         emitIdById[typeVal] ||= [
           _id: typeVal
         ,
-          $pushAll:
-            ids: []
+          $push:
+            ids:
+              $each: []
         ]
-        emitIdById[typeVal][1].$pushAll.ids.push emitData._id
+        emitIdById[typeVal][1].$push.ids.$each.push emitData._id
       async.parallel [
         (done) => @emitMongo.bulkInsert emitDatas, done
         (done) => @emitidsMongo.bulkUpdate _.values(emitIdById), done


### PR DESCRIPTION
mongodb 3.6.2 or later doesn't support $pushAll.
So replace pushAll to push + each